### PR TITLE
Adapt to recent openjdk changes

### DIFF
--- a/closed/CopySupport.gmk
+++ b/closed/CopySupport.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -110,11 +110,11 @@ openj9_copy_files_and_debuginfos = \
 
 # openj9_copy_exes
 # ----------------
-# $1 = list of executable names without $(EXE_SUFFIX)
+# $1 = list of executable names without $(EXECUTABLE_SUFFIX)
 openj9_copy_exes = \
 	$(foreach file, $1, \
 		$(call openj9_copy_files_and_debuginfos, \
-			$(addsuffix /$(file)$(EXE_SUFFIX), \
+			$(addsuffix /$(file)$(EXECUTABLE_SUFFIX), \
 				$(OPENJ9_VM_BUILD_DIR) \
 				$(EXE_DST_DIR))))
 

--- a/closed/GensrcJ9JCL.gmk
+++ b/closed/GensrcJ9JCL.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2020, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2020, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -48,7 +48,7 @@ $(J9JCL_SOURCES_DONEFILE) : $(AllJclSource)
 		BOOT_JDK=$(BOOT_JDK) \
 		DEST_DIR=$(call FixPath,$(J9TOOLS_DIR)) \
 		JAVA_HOME=$(BOOT_JDK) \
-		$(call FixPath,$(JPP_JAR))
+		preprocessor
 	@$(ECHO) Generating J9JCL sources
 	@$(BOOT_JDK)/bin/java \
 		-cp "$(call FixPath,$(JPP_JAR))" \

--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -87,11 +87,10 @@ endif
 
 ifeq (windows,$(OPENJDK_TARGET_OS))
   # convert windows path to unix path
-  UnixPath = $(shell $(CYGPATH) -u $1)
+  UnixPath = $(shell $(PATHTOOL) -u $1)
   # set Visual Studio environment
   # wrap PATH in quotes as it contains spaces (unix path)
-  # INCLUDE, LIB are already wrapped in quotes (windows paths)
-  EXPORT_MSVS_ENV_VARS := PATH="$(PATH)" INCLUDE=$(INCLUDE) LIB=$(LIB)
+  EXPORT_MSVS_ENV_VARS := PATH="$(PATH)"
 else
   UnixPath = $1
   EXPORT_MSVS_ENV_VARS :=
@@ -134,7 +133,7 @@ define openj9_test_image_rules
 endef
 
 $(foreach file, \
-	$(patsubst %, $(OPENJ9_VM_BUILD_DIR)/%$(EXE_SUFFIX), \
+	$(patsubst %, $(OPENJ9_VM_BUILD_DIR)/%$(EXECUTABLE_SUFFIX), \
 		algotest \
 		bcvunit \
 		cfdump \

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -168,7 +168,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_CUDA],
       if test -f "$cuda_home/include/cuda.h" ; then
         if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin ; then
           # UTIL_FIXUP_PATH yields a Unix-style path, but we need a mixed-mode path
-          cuda_home="`$CYGPATH -m $cuda_home`"
+          cuda_home="`$PATHTOOL -m $cuda_home`"
         fi
         if test "$cuda_home" = "$with_cuda" ; then
           AC_MSG_RESULT([$with_cuda])
@@ -190,7 +190,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_CUDA],
       if test -f "$gdk_home/include/nvml.h" ; then
         if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin ; then
           # UTIL_FIXUP_PATH yields a Unix-style path, but we need a mixed-mode path
-          gdk_home="`$CYGPATH -m $gdk_home`"
+          gdk_home="`$PATHTOOL -m $gdk_home`"
         fi
         if test "$gdk_home" = "$with_gdk" ; then
           AC_MSG_RESULT([$with_gdk])
@@ -464,7 +464,7 @@ AC_DEFUN([OPENJ9_THIRD_PARTY_REQUIREMENTS],
     fi
 
     if test "x$OPENJDK_BUILD_OS_ENV" = xwindows.cygwin ; then
-      FREEMARKER_JAR=`$CYGPATH -m "$with_freemarker_jar"`
+      FREEMARKER_JAR=`$PATHTOOL -m "$with_freemarker_jar"`
     else
       FREEMARKER_JAR=$with_freemarker_jar
     fi
@@ -529,6 +529,13 @@ AC_DEFUN_ONCE([CUSTOM_LATE_HOOK],
     AC_SUBST([OPENJ9_TOOL_DIR])
     OPENJ9_GENERATE_TOOL_WRAPPERS
     AC_CONFIG_FILES([$OUTPUTDIR/toolchain-win.cmake:$CLOSED_AUTOCONF_DIR/toolchain-win.cmake.in])
+
+    # We used to rely on VS_INCLUDE and VS_LIB directly, but those are no longer available
+    # for substitutions, and they're not Windows-style paths: Convert them for our use.
+    OPENJ9_VS_INCLUDE=`$PATHTOOL -p -w "$VS_INCLUDE"`
+    OPENJ9_VS_LIB=`$PATHTOOL -p -w "$VS_LIB"`
+    AC_SUBST(OPENJ9_VS_INCLUDE)
+    AC_SUBST(OPENJ9_VS_LIB)
   fi
 ])
 

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -115,8 +115,8 @@ export ac_cv_prog_CXX   := @CXX@
 ifeq ($(OPENJDK_TARGET_OS), windows)
   # Set environment variables for Microsoft Visual Studio toolchain.
   # Note that PATH is set in spec.gmk.
-  export INCLUDE := "@VS_INCLUDE@"
-  export LIB := "@VS_LIB@"
+  export INCLUDE := @OPENJ9_VS_INCLUDE@
+  export LIB := @OPENJ9_VS_LIB@
   export MSVC_VERSION := @TOOLCHAIN_VERSION@
 endif
 

--- a/make/scripts/fixpath.sh
+++ b/make/scripts/fixpath.sh
@@ -24,6 +24,10 @@
 # questions.
 #
 
+# ===========================================================================
+# (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+# ===========================================================================
+
 # Setup the environment fixpath assumes. Read from command line options if
 # available, or extract values automatically from the environment if missing.
 # This is robust, but slower.
@@ -328,7 +332,9 @@ function convert_path() {
     fi
   fi
 
-  if [[ $winpath != "" ]]; then
+  # If the prefix ends with "." or "..", assume that it's
+  # part of a relative path that we don't want to change.
+  if [[ $winpath != "" && ! $prefix =~ (\.|\.\.)$ ]] ; then
     result="$prefix$winpath"
   else
     # Return the arg unchanged


### PR DESCRIPTION
* fix handling of relative paths by `fixpath.sh`; we don't want to map arguments like
    `-I../../include`
  to
    `-I..C:\cygwin\..\include`
  The original version treated the first slash as if it were the beginning of an absolute path.

* update the use of `buildj9tools.mk` to build the java preprocessor to avoid issues due to changes to `FixPath`

* compute `OPENJ9_VS_INCLUDE` and `OPENJ9_VS_LIB` and make available for substitutions (replacing `VS_INCLUDE` and `VS_LIB`)

* remove redundant exports
  - `INCLUDE` and `LIB` are exported by `custom-spec.gmk`

* adjust macro references
  - `CYGPATH`    -> `PATHTOOL`
  - `EXE_SUFFIX` -> `EXECUTABLE_SUFFIX`

This is a back-port of ibmruntimes/openj9-openjdk-jdk#263 for Java 16.