### PR TITLE
Revert '--add-exports=openj9.dtfj/com.ibm.dtfj.utils=ALL-UNNAMED'

### DIFF
--- a/closed/make/modules/openj9.dtfjview/Launcher.gmk
+++ b/closed/make/modules/openj9.dtfjview/Launcher.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -24,5 +24,4 @@ $(eval $(call SetupBuildLauncher, jdmpview, \
     MAIN_MODULE := openj9.dtfjview, \
     MAIN_CLASS := com.ibm.jvm.dtfjview.DTFJView, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
-    JAVA_ARGS := --add-exports=openj9.dtfj/com.ibm.dtfj.utils=ALL-UNNAMED, \
 ))


### PR DESCRIPTION
Now done programmatically in `com.ibm.dtfj.image.j9.ImageFactory` via eclipse/openj9#11597.