### PR TITLE
Include j9vrb_full library in mixed references builds

### DIFF
--- a/closed/custom/modules/java.base/Copy.gmk
+++ b/closed/custom/modules/java.base/Copy.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -69,6 +69,7 @@ $(call openj9_copy_shlibs, \
 	j9vm29 \
 	j9vmchk29 \
 	j9vrb29 \
+	$(if $(filter static,$(OMR_MIXED_REFERENCES_MODE)),j9vrb_full29) \
 	j9zlib29 \
 	jclse29 \
 	jvm \


### PR DESCRIPTION
Port of: https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/378

Depends on: eclipse/openj9#11662

Includes the j9vrb_full library in the JDK for mixed references builds.