### PR TITLE
OpenJ9 support for the Foreign Memory Access API

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -23,6 +23,11 @@
  *  questions.
  *
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved.
+ * ===========================================================================
+ */
 
 package java.lang.invoke;
 
@@ -45,7 +50,7 @@ import java.util.function.BiFunction;
 /* package */ class IndirectVarHandle extends VarHandle {
 
     @Stable
-    private final MethodHandle[] handleMap = new MethodHandle[AccessMode.values().length];
+    private final MethodHandle[] handleMap;
     private final VarHandle directTarget; // cache, for performance reasons
     private final VarHandle target;
     private final BiFunction<AccessMode, MethodHandle, MethodHandle> handleFactory;
@@ -64,6 +69,7 @@ import java.util.function.BiFunction;
         this.directTarget = target.asDirect();
         this.value = value;
         this.coordinates = coordinates;
+        this.handleMap = this.handleTable = VarHandle.populateMHsJEP383(target, handleFactory);
     }
 
     @Override
@@ -114,14 +120,15 @@ import java.util.function.BiFunction;
     MethodHandle getMethodHandle(int mode) {
         MethodHandle handle = handleMap[mode];
         if (handle == null) {
-            MethodHandle targetHandle = target.getMethodHandle(mode); // might throw UOE of access mode is not supported, which is ok
-            handle = handleMap[mode] = handleFactory.apply(AccessMode.values()[mode], targetHandle);
+            /* OpenJ9 pre-initializes the handleMap in the constructor. So, there is no need to reapply handleFactory here. */
+            handle = target.getMethodHandle(mode); // might throw UOE of access mode is not supported, which is ok
         }
         return handle;
     }
 
     @Override
     public MethodHandle toMethodHandle(AccessMode accessMode) {
-        return getMethodHandle(accessMode.ordinal()).bindTo(directTarget);
+        MethodHandle mh = getMethodHandle(accessMode.ordinal());
+        return MethodHandles.insertArguments(mh, mh.type().parameterCount() - 1, directTarget);
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -22,6 +22,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved.
+ * ===========================================================================
+ */
 
 package java.lang.invoke;
 
@@ -349,13 +354,7 @@ final class VarHandles {
     }
 
     private static VarHandle maybeAdapt(VarHandle target) {
-        if (!VAR_HANDLE_IDENTITY_ADAPT) return target;
-        target = filterValue(target,
-                        MethodHandles.identity(target.varType()), MethodHandles.identity(target.varType()));
-        MethodType mtype = target.accessModeType(VarHandle.AccessMode.GET);
-        for (int i = 0 ; i < mtype.parameterCount() ; i++) {
-            target = filterCoordinates(target, i, MethodHandles.identity(mtype.parameterType(i)));
-        }
+        /* This optimization is disabled in OpenJ9. */
         return target;
     }
 
@@ -631,7 +630,7 @@ final class VarHandles {
             }
         } else if (handle instanceof DelegatingMethodHandle) {
             noCheckedExceptions(((DelegatingMethodHandle)handle).getTarget());
-        } else {
+        } else if (handle instanceof BoundMethodHandle) {
             //bound
             BoundMethodHandle boundHandle = (BoundMethodHandle)handle;
             for (int i = 0 ; i < boundHandle.fieldCount() ; i++) {
@@ -639,6 +638,11 @@ final class VarHandles {
                 if (arg instanceof MethodHandle){
                     noCheckedExceptions((MethodHandle) arg);
                 }
+            }
+        } else {
+            /* Temporary code to handle OpenJ9's MethodHandle implementation. This will be removed in a future release. */
+            if (MethodHandles.hasCheckedException(handle)) {
+                throw newIllegalArgumentException("Cannot adapt a var handle with a method handle which throws checked exceptions");
             }
         }
     }


### PR DESCRIPTION
**Note: This PR needs to be reverted once OJDK MHs are enabled in OpenJ9.**

**The following methods have been updated:**

- IndirectVarHandle's constructor
- IndirectVarHandle.getMethodHandle
- IndirectVarHandle.toMethodHandle
- VarHandles.maybeAdapt
- VarHandles.noCheckedExceptions

**This PR is identical to:**
- https://github.com/ibmruntimes/openj9-openjdk-jdk15/pull/11
- https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/248

Already been reviewed in https://github.com/ibmruntimes/openj9-openjdk-jdk15/pull/11 for JDK15.

Related issues:
- https://github.com/eclipse/openj9/issues/11135
- https://github.com/eclipse/openj9/issues/10455
- https://github.com/eclipse/openj9/issues/11724

**This should resolve the following exception:**
```
java.lang.ClassCastException: java.lang.invoke.DirectHandle incompatible with java.lang.invoke.BoundMethodHandle
```

**The following tests should pass with these changes:**
```
java/foreign/TestArrays.java
java/foreign/TestLayouts.java
java/foreign/TestLayoutPaths.java
java/foreign/TestLayoutConstants.java
java/foreign/TestAdaptVarHandles.java
java/foreign/TestAddressHandle.java
java/foreign/TestIllegalLink.java
java/foreign/TestMemoryAccess.java
java/foreign/TestMemoryAccessStatics.java
java/foreign/TestMemoryAlignment.java
java/foreign/TestMemoryCopy.java
java/foreign/TestMemoryHandleAsUnsigned.java
java/foreign/TestMismatch.java
java/foreign/TestNulls.java
java/foreign/TestRebase.java
java/foreign/TestSegments.java
java/foreign/TestSlices.java
java/foreign/TestTypeAccess.java
java/foreign/TestVarHandleCombinators.java
java/util/stream/test/org/openjdk/tests/java/util/stream/SegmentTestDataProvider.java
java/util/stream/test/org/openjdk/tests/java/util/stream/SpliteratorTest.java
```

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>