### PR TITLE
Enable cmake for AIX by default

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -61,7 +61,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_CMAKE],
     ],
     [
       case "$OPENJ9_PLATFORM_CODE" in
-        oa64|wa64|xa64|xl64|xr64|xz64)
+        ap64|oa64|wa64|xa64|xl64|xr64|xz64)
           if test "x$COMPILE_TYPE" != xcross ; then
             with_cmake=cmake
           else


### PR DESCRIPTION
This is tested by the nightly build running a mixed build, which enables cmake.

https://ci.eclipse.org/openj9/job/Pipeline_Build_Test_JDK16_ppc64_aix_mixed/2

The build isn't yet finished, but no failures on AIX have occurred so far.

The following are completed successfully already:
https://ci.eclipse.org/openj9/job/Test_openjdk16_j9_sanity.functional_ppc64_aix_mixed_Nightly/1/
https://ci.eclipse.org/openj9/job/Test_openjdk16_j9_extended.functional_ppc64_aix_mixed_Nightly/1/
https://ci.eclipse.org/openj9/job/Test_openjdk16_j9_sanity.openjdk_ppc64_aix_mixed_Nightly/1/
