### PR TITLE
(0.25.0) Enable cmake for AIX by default

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -61,7 +61,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_CMAKE],
     ],
     [
       case "$OPENJ9_PLATFORM_CODE" in
-        oa64|wa64|xa64|xl64|xr64|xz64)
+        ap64|oa64|wa64|xa64|xl64|xr64|xz64)
           if test "x$COMPILE_TYPE" != xcross ; then
             with_cmake=cmake
           else


### PR DESCRIPTION
Cherry pick of https://github.com/ibmruntimes/openj9-openjdk-jdk16/pull/20 for the 0.25 release.