### PR TITLE
Update the 0.25.0 release branch with 16+36

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -690,7 +690,7 @@ AC_DEFUN([CONFIGURE_OPENSSL],
 
 # Create a tool wrapper for use by cmake.
 # Consists of a shell script which wraps commands with an invocation of fixpath.
-# OPENJ9_GENERATE_TOOL_WRAPER(<name_of_wrapper>, <command_to_call>)
+# OPENJ9_GENERATE_TOOL_WRAPPER(<name_of_wrapper>, <command_to_call>)
 AC_DEFUN([OPENJ9_GENERATE_TOOL_WRAPPER],
 [
   tool_file="$OPENJ9_TOOL_DIR/$1"

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -61,7 +61,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_CMAKE],
     ],
     [
       case "$OPENJ9_PLATFORM_CODE" in
-        oa64|xa64|xl64|xr64|xz64)
+        oa64|wa64|xa64|xl64|xr64|xz64)
           if test "x$COMPILE_TYPE" != xcross ; then
             with_cmake=cmake
           else

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -61,7 +61,7 @@ AC_DEFUN([OPENJ9_CONFIGURE_CMAKE],
     ],
     [
       case "$OPENJ9_PLATFORM_CODE" in
-        oa64|wa64|xa64|xl64|xr64|xz64)
+        ap64|oa64|wa64|xa64|xl64|xr64|xz64)
           if test "x$COMPILE_TYPE" != xcross ; then
             with_cmake=cmake
           else

--- a/closed/openjdk-tag.gmk
+++ b/closed/openjdk-tag.gmk
@@ -1,1 +1,1 @@
-OPENJDK_TAG := jdk-16+35
+OPENJDK_TAG := jdk-16+36

--- a/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CipherCore.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2019 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2021 All Rights Reserved
  * ===========================================================================
  */
 
@@ -1308,7 +1308,11 @@ final class CipherCore {
             return cipher.decryptFinal(src, dst);
         } else {
             if (buffered > 0) {
-                ((GaloisCounterMode)cipher).encrypt(buffer, 0, buffered);
+                if (useNativeGCM) {
+                    ((NativeGaloisCounterMode) cipher).encrypt(buffer, 0, buffered);
+                } else {
+                    ((GaloisCounterMode) cipher).encrypt(buffer, 0, buffered);
+                }
             }
             return cipher.encryptFinal(src, dst);
         }

--- a/test/hotspot/jtreg/compiler/loopopts/TestLoadPinnedAfterAllocate.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestLoadPinnedAfterAllocate.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8260709
+ * @summary C2: assert(false) failed: unscheduable graph
+ *
+ * @run main/othervm -XX:-BackgroundCompilation TestLoadPinnedAfterAllocate
+ *
+ */
+
+public class TestLoadPinnedAfterAllocate {
+    private int field;
+    private static volatile int barrier;
+    private static Object field2;
+
+    public static void main(String[] args) {
+        final TestLoadPinnedAfterAllocate test = new TestLoadPinnedAfterAllocate();
+        for (int i = 0; i < 20_000; i++) {
+            test.test(1, 10);
+        }
+    }
+
+    private int test(int start, int stop) {
+        int[] array = new int[10];
+        for (int j = 0; j < 10; j++) {
+            barrier = 1;
+            // early control for field load below
+            for (int i = 1; i < 10; i *= 2) {
+                field2 = array;
+                array = new int[10];
+                // late control for field load below
+            }
+        }
+        int v = field;
+        array[0] = v;
+        return v+v;
+    }
+}

--- a/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMBufferTest.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/AEAD/GCMBufferTest.java
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * ===========================================================================
+ */
 
 /*
  * @test
@@ -62,7 +67,9 @@ public class GCMBufferTest implements Cloneable {
     int[] sizes;
     boolean incremental = false;
     // In some cases the theoretical check is too complicated to verify
-    boolean theoreticalCheck;
+    boolean theoreticalCheckFinal;
+    // This variable is never set to true in order to disable length verification after cipher.update for GCM Buffer Tests
+    boolean theoreticalCheckUpdate;
     List<Data> dataSet;
     int inOfs = 0, outOfs = 0;
 
@@ -128,7 +135,8 @@ public class GCMBufferTest implements Cloneable {
     GCMBufferTest(String algo, List<dtype> ops) {
         this.algo = algo;
         this.ops = ops;
-        theoreticalCheck = true;
+        theoreticalCheckUpdate = false;
+        theoreticalCheckFinal = true;
         dataSet = datamap.get(algo);
     }
 
@@ -416,7 +424,7 @@ public class GCMBufferTest implements Cloneable {
                     default -> throw new Exception("Unknown op: " + v.name());
                 }
 
-                if (theoreticalCheck) {
+                if (theoreticalCheckUpdate) {
                     pbuflen += plen - rlen;
                     if (encrypt && rlen != theoreticallen) {
                         throw new Exception("Wrong update return len (" +
@@ -473,7 +481,7 @@ public class GCMBufferTest implements Cloneable {
                     default -> throw new Exception("Unknown op: " + v.name());
                 }
 
-                if (theoreticalCheck && rlen != olen - outOfs) {
+                if (theoreticalCheckFinal && rlen != olen - outOfs) {
                     throw new Exception("Wrong doFinal return len (" +
                         v.name() + "):  " + "rlen=" + rlen +
                         ", expected output len=" + (olen - outOfs));
@@ -569,7 +577,7 @@ public class GCMBufferTest implements Cloneable {
                 }
 
                 // Check that the theoretical return value matches the actual.
-                if (theoreticalCheck && encrypt && rlen != theorticallen) {
+                if (theoreticalCheckUpdate && encrypt && rlen != theorticallen) {
                     throw new Exception("Wrong update return len (" +
                         v.name() + "):  " + "rlen=" + rlen +
                         ", expected output len=" + theorticallen);

--- a/test/jdk/java/foreign/TestLibraryLookup.java
+++ b/test/jdk/java/foreign/TestLibraryLookup.java
@@ -22,6 +22,12 @@
  */
 
 /*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved.
+ * ===========================================================================
+ */
+
+/*
  * @test
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
  * @modules jdk.incubator.foreign/jdk.internal.foreign
@@ -82,6 +88,7 @@ public class TestLibraryLookup {
         LibraryLookup lookup = LibraryLookup.ofLibrary("LookupTest");
         assertTrue(lookup.lookup("nonExistent").isEmpty());
         assertEquals(LibrariesHelper.numLoadedLibraries(), 1);
+        java.lang.ref.Reference.reachabilityFence(lookup);
         lookup = null;
         symbol = null;
         waitUnload();


### PR DESCRIPTION
Note that most of these changes are already double delivered so there is less change to content being merged than appears in the file changes shown by this PR. Maybe we should have merged openj9 rather than double delivering the individual changes. We could deliver the new content another way to avoid the duplicate commits, but having the original commits is better.

See https://github.com/ibmruntimes/openj9-openjdk-jdk16/compare/v0.25.0-release..openj9 for the differences between branches.