### PR TITLE
JDK16 extension changes to enable OJDK MHs

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -372,15 +372,15 @@ AC_DEFUN([OPENJ9_CONFIGURE_OPENJDK_METHODHANDLES],
 [
   AC_MSG_CHECKING([for openjdk-methodhandles])
   AC_ARG_ENABLE([openjdk-methodhandles], [AS_HELP_STRING([--enable-openjdk-methodhandles], [enable support for OpenJDK MethodHandles @<:@disabled@:>@])])
-  OPENJ9_ENABLE_OPENJDK_METHODHANDLES=false
-
   if test "x$enable_openjdk_methodhandles" = xyes ; then
     AC_MSG_RESULT([yes (explicitly enabled)])
     OPENJ9_ENABLE_OPENJDK_METHODHANDLES=true
   elif test "x$enable_openjdk_methodhandles" = xno ; then
     AC_MSG_RESULT([no (explicitly disabled)])
+    OPENJ9_ENABLE_OPENJDK_METHODHANDLES=false
   elif test "x$enable_openjdk_methodhandles" = x ; then
-    AC_MSG_RESULT([no (default)])
+    AC_MSG_RESULT([yes (default)])
+    OPENJ9_ENABLE_OPENJDK_METHODHANDLES=true
   else
     AC_MSG_ERROR([--enable-openjdk-methodhandles accepts no argument])
   fi

--- a/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/IndirectVarHandle.java
@@ -23,11 +23,6 @@
  *  questions.
  *
  */
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved.
- * ===========================================================================
- */
 
 package java.lang.invoke;
 
@@ -50,7 +45,7 @@ import java.util.function.BiFunction;
 /* package */ class IndirectVarHandle extends VarHandle {
 
     @Stable
-    private final MethodHandle[] handleMap;
+    private final MethodHandle[] handleMap = new MethodHandle[AccessMode.values().length];
     private final VarHandle directTarget; // cache, for performance reasons
     private final VarHandle target;
     private final BiFunction<AccessMode, MethodHandle, MethodHandle> handleFactory;
@@ -69,7 +64,6 @@ import java.util.function.BiFunction;
         this.directTarget = target.asDirect();
         this.value = value;
         this.coordinates = coordinates;
-        this.handleMap = this.handleTable = VarHandle.populateMHsJEP383(target, handleFactory);
     }
 
     @Override
@@ -120,15 +114,14 @@ import java.util.function.BiFunction;
     MethodHandle getMethodHandle(int mode) {
         MethodHandle handle = handleMap[mode];
         if (handle == null) {
-            /* OpenJ9 pre-initializes the handleMap in the constructor. So, there is no need to reapply handleFactory here. */
-            handle = target.getMethodHandle(mode); // might throw UOE of access mode is not supported, which is ok
+            MethodHandle targetHandle = target.getMethodHandle(mode); // might throw UOE of access mode is not supported, which is ok
+            handle = handleMap[mode] = handleFactory.apply(AccessMode.values()[mode], targetHandle);
         }
         return handle;
     }
 
     @Override
     public MethodHandle toMethodHandle(AccessMode accessMode) {
-        MethodHandle mh = getMethodHandle(accessMode.ordinal());
-        return MethodHandles.insertArguments(mh, mh.type().parameterCount() - 1, directTarget);
+        return getMethodHandle(accessMode.ordinal()).bindTo(directTarget);
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -5748,6 +5748,10 @@ assertEquals("[top, [[up, down, strange], charm], bottom]",
         MethodType filterType = filter.type();
         Class<?> rtype = filterType.returnType();
         List<Class<?>> filterArgs = filterType.parameterList();
+        if (pos < 0 || (rtype == void.class && pos > targetType.parameterCount()) ||
+                       (rtype != void.class && pos >= targetType.parameterCount())) {
+            throw newIllegalArgumentException("position is out of range for target", target, pos);
+        }
         if (rtype == void.class) {
             return targetType.insertParameterTypes(pos, filterArgs);
         }

--- a/src/java.base/share/classes/java/lang/invoke/VarHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandles.java
@@ -22,11 +22,6 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved.
- * ===========================================================================
- */
 
 package java.lang.invoke;
 
@@ -354,7 +349,13 @@ final class VarHandles {
     }
 
     private static VarHandle maybeAdapt(VarHandle target) {
-        /* This optimization is disabled in OpenJ9. */
+        if (!VAR_HANDLE_IDENTITY_ADAPT) return target;
+        target = filterValue(target,
+                        MethodHandles.identity(target.varType()), MethodHandles.identity(target.varType()));
+        MethodType mtype = target.accessModeType(VarHandle.AccessMode.GET);
+        for (int i = 0 ; i < mtype.parameterCount() ; i++) {
+            target = filterCoordinates(target, i, MethodHandles.identity(mtype.parameterType(i)));
+        }
         return target;
     }
 
@@ -630,7 +631,7 @@ final class VarHandles {
             }
         } else if (handle instanceof DelegatingMethodHandle) {
             noCheckedExceptions(((DelegatingMethodHandle)handle).getTarget());
-        } else if (handle instanceof BoundMethodHandle) {
+        } else {
             //bound
             BoundMethodHandle boundHandle = (BoundMethodHandle)handle;
             for (int i = 0 ; i < boundHandle.fieldCount() ; i++) {
@@ -638,11 +639,6 @@ final class VarHandles {
                 if (arg instanceof MethodHandle){
                     noCheckedExceptions((MethodHandle) arg);
                 }
-            }
-        } else {
-            /* Temporary code to handle OpenJ9's MethodHandle implementation. This will be removed in a future release. */
-            if (MethodHandles.hasCheckedException(handle)) {
-                throw newIllegalArgumentException("Cannot adapt a var handle with a method handle which throws checked exceptions");
             }
         }
     }

--- a/test/jdk/java/lang/invoke/MethodHandlesCollectArgsTest.java
+++ b/test/jdk/java/lang/invoke/MethodHandlesCollectArgsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8259922
+ * @run testng/othervm MethodHandlesCollectArgsTest
+ */
+
+import org.testng.annotations.Test;
+import org.testng.annotations.DataProvider;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import static java.lang.invoke.MethodType.methodType;
+
+import static org.testng.Assert.*;
+
+public class MethodHandlesCollectArgsTest {
+
+    private static final MethodHandle TARGET_II_I = MethodHandles.empty(methodType(int.class, int.class, int.class));
+    private static final MethodHandle TARGET__V = MethodHandles.empty(methodType(void.class));
+    private static final MethodHandle FILTER_INT = MethodHandles.empty(methodType(int.class, String.class));
+    private static final MethodHandle FILTER_VOID = MethodHandles.empty(methodType(void.class, String.class));
+
+    @DataProvider(name = "illegalPos")
+    public static Object[][] illegalPos() {
+        return new Object[][] {
+            {TARGET_II_I, 2, FILTER_INT},
+            {TARGET_II_I, 3, FILTER_VOID},
+            {TARGET_II_I, -1, FILTER_INT},
+            {TARGET_II_I, -1, FILTER_VOID},
+            {TARGET__V, 0, FILTER_INT},
+            {TARGET__V, 1, FILTER_VOID},
+            {TARGET__V, -1, FILTER_VOID},
+            {TARGET__V, -1, FILTER_VOID}
+        };
+    }
+
+    @DataProvider(name = "validPos")
+    public static Object[][] validPos() {
+        return new Object[][] {
+            {TARGET_II_I, 0, FILTER_INT, methodType(int.class, String.class, int.class)},
+            {TARGET_II_I, 1, FILTER_INT, methodType(int.class, int.class, String.class)},
+            {TARGET_II_I, 0, FILTER_VOID, methodType(int.class, String.class, int.class, int.class)},
+            {TARGET_II_I, 1, FILTER_VOID, methodType(int.class, int.class, String.class, int.class)},
+            {TARGET_II_I, 2, FILTER_VOID, methodType(int.class, int.class, int.class, String.class)},
+            {TARGET__V, 0, FILTER_VOID, methodType(void.class, String.class)}
+        };
+    }
+
+    @Test(dataProvider="illegalPos", expectedExceptions = {IllegalArgumentException.class})
+    public void illegalPosition(MethodHandle target, int position, MethodHandle filter) {
+        MethodHandles.collectArguments(target, position, filter);
+    }
+
+    @Test(dataProvider="validPos")
+    public void legalPosition(MethodHandle target, int position, MethodHandle filter, MethodType expectedType) {
+        MethodHandle result = MethodHandles.collectArguments(target, position, filter);
+        assertEquals(result.type(), expectedType);
+    }
+}


### PR DESCRIPTION
1. Revert "OpenJ9 support for the Foreign Memory Access API" 
2. 8259922: MethodHandles.collectArguments does not throw IAE if pos is … (back-ported from JDK-next)
3. Enable OpenJDK MHs for OpenJ9 JDK16 by default (back-ported from https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/308 + https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/309)

This PR is created to launch OpenJ9 PR build jobs with OJDK MHs enabled in OpenJ9.

It should not be merged.