### PR TITLE
Remove redundant launcher specifications of MAIN_MODULE

### DIFF
--- a/closed/make/modules/jdk.jcmd/Launcher.gmk
+++ b/closed/make/modules/jdk.jcmd/Launcher.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2019, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2019, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -21,32 +21,27 @@
 include LauncherCommon.gmk
 
 $(eval $(call SetupBuildLauncher, jcmd, \
-    MAIN_MODULE := jdk.jcmd, \
     MAIN_CLASS := openj9.tools.attach.diagnostics.tools.Jcmd, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
 ))
 
 $(eval $(call SetupBuildLauncher, jmap, \
-    MAIN_MODULE := jdk.jcmd, \
     MAIN_CLASS := openj9.tools.attach.diagnostics.tools.Jmap, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
 ))
 
 $(eval $(call SetupBuildLauncher, jps, \
-    MAIN_MODULE := jdk.jcmd, \
     MAIN_CLASS := openj9.tools.attach.diagnostics.tools.Jps, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
     JAVA_ARGS := -Djdk.attach.allowAttachSelf=true, \
 ))
 
 $(eval $(call SetupBuildLauncher, jstack, \
-    MAIN_MODULE := jdk.jcmd, \
     MAIN_CLASS := openj9.tools.attach.diagnostics.tools.Jstack, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
 ))
 
 $(eval $(call SetupBuildLauncher, jstat, \
-    MAIN_MODULE := jdk.jcmd, \
     MAIN_CLASS := openj9.tools.attach.diagnostics.tools.Jstat, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
 ))

--- a/closed/make/modules/openj9.dtfj/Launcher.gmk
+++ b/closed/make/modules/openj9.dtfj/Launcher.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -21,7 +21,6 @@
 include LauncherCommon.gmk
 
 $(eval $(call SetupBuildLauncher, jextract, \
-    MAIN_MODULE := openj9.dtfj, \
     MAIN_CLASS := com.ibm.jvm.j9.dump.extract.Main, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
 ))

--- a/closed/make/modules/openj9.dtfjview/Launcher.gmk
+++ b/closed/make/modules/openj9.dtfjview/Launcher.gmk
@@ -21,7 +21,6 @@
 include LauncherCommon.gmk
 
 $(eval $(call SetupBuildLauncher, jdmpview, \
-    MAIN_MODULE := openj9.dtfjview, \
     MAIN_CLASS := com.ibm.jvm.dtfjview.DTFJView, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
 ))

--- a/closed/make/modules/openj9.traceformat/Launcher.gmk
+++ b/closed/make/modules/openj9.traceformat/Launcher.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2020 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2021 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -21,7 +21,6 @@
 include LauncherCommon.gmk
 
 $(eval $(call SetupBuildLauncher, traceformat, \
-    MAIN_MODULE := openj9.traceformat, \
     MAIN_CLASS := com.ibm.jvm.traceformat.TraceFormat, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
 ))


### PR DESCRIPTION
`MAIN_MODULE` only needs to be specified when the main class is not in the current module.

This is a replay of ibmruntimes/openj9-openjdk-jdk11#397 for Java 16.