### PR TITLE
Add new jpackcore launcher

### DIFF
--- a/closed/make/modules/openj9.dtfj/Launcher.gmk
+++ b/closed/make/modules/openj9.dtfj/Launcher.gmk
@@ -24,3 +24,8 @@ $(eval $(call SetupBuildLauncher, jextract, \
     MAIN_CLASS := com.ibm.jvm.j9.dump.extract.Main, \
     CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
 ))
+
+$(eval $(call SetupBuildLauncher, jpackcore, \
+    MAIN_CLASS := com.ibm.jvm.j9.dump.extract.Main, \
+    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS, \
+))


### PR DESCRIPTION
Equivalent to `jextract` which will clash with an upstream tool.

See eclipse/openj9#11278.