### PR TITLE
In test, increase deflate buffer size for zlinux Ubuntu 20

### DIFF
--- a/test/jdk/java/util/zip/DeInflate.java
+++ b/test/jdk/java/util/zip/DeInflate.java
@@ -20,6 +20,11 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * ===========================================================================
+ */
 
 /**
  * @test
@@ -268,7 +273,7 @@ public class DeInflate {
 
         byte[] dataIn = new byte[1024 * 512];
         rnd.nextBytes(dataIn);
-        byte[] dataOut1 = new byte[dataIn.length + 1024];
+        byte[] dataOut1 = new byte[dataIn.length + (32 * 1024)]; // See https://github.com/eclipse-openj9/openj9/issues/12740
         byte[] dataOut2 = new byte[dataIn.length];
 
         Deflater defNotWrap = new Deflater(Deflater.DEFAULT_COMPRESSION, false);


### PR DESCRIPTION
test/jdk/java/util/zip/DeInflate.java

Issue eclipse-openj9/openj9#12740

Port of https://github.com/ibmruntimes/openj9-openjdk-jdk11
It's the same change so I don't think it needs testing, but let me know if you want a grinder.