### PR TITLE
[JDK16] Fix the bug with the return type of the omitted finalizers in loop

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -23,6 +23,12 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2021, 2021 All Rights Reserved
+ * ===========================================================================
+ */
+
 package java.lang.invoke;
 
 import jdk.internal.access.SharedSecrets;
@@ -6675,7 +6681,7 @@ assertEquals("boojum", (String) catTrace.invokeExact("boo", "jum"));
                 pred.set(i, dropArguments0(constant(boolean.class, true), 0, commonParameterSequence));
             }
             if (fini.get(i) == null) {
-                fini.set(i, empty(methodType(t, commonParameterSequence)));
+                fini.set(i, empty(methodType(loopReturnType, commonParameterSequence)));
             }
         }
 


### PR DESCRIPTION
The change is to fix the bug with the return type of the omitted
finalizers as OpenJDK doesn't follow the Spec to set the loop
return type.

Fixes: eclipse-openj9/openj9#11937

Signed-off-by: Cheng Jin <jincheng@ca.ibm.com>