### PR TITLE
Fix NativeCrypto when AES-GCM is used concurrently

### DIFF
--- a/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
+++ b/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeCipherBlockChaining.java
@@ -24,7 +24,7 @@
  */
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2018, 2020 All Rights Reserved
+ * (c) Copyright IBM Corp. 2018, 2021 All Rights Reserved
  * ===========================================================================
  */
 
@@ -182,7 +182,10 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
 
         mode = (decrypting) ? 0 : 1;
 
-        int ret = nativeCrypto.CBCInit(nativeContext, mode, iv, iv.length, key, key.length);
+        int ret;
+        synchronized (this) {
+            ret = nativeCrypto.CBCInit(nativeContext, mode, iv, iv.length, key, key.length);
+        }
         if (ret == -1) {
             throw new ProviderException("Error in Native CipherBlockChaining");
         }
@@ -196,7 +199,10 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
      */
     void reset() {
         System.arraycopy(iv, 0, r, 0, blockSize);
-        int ret = nativeCrypto.CBCInit(nativeContext, mode, iv, iv.length, key, key.length);
+        int ret;
+        synchronized (this) {
+            ret = nativeCrypto.CBCInit(nativeContext, mode, iv, iv.length, key, key.length);
+        }
         if (ret == -1) {
             throw new ProviderException("Error in Native CipherBlockChaining");
         }
@@ -217,7 +223,10 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
      */
     void restore() {
         System.arraycopy(rSave, 0, r, 0, blockSize);
-        int ret = nativeCrypto.CBCInit(nativeContext, mode, r, r.length, key, key.length);
+        int ret;
+        synchronized (this) {
+            ret = nativeCrypto.CBCInit(nativeContext, mode, r, r.length, key, key.length);
+        }
         if (ret == -1) {
             throw new ProviderException("Error in Native CipherBlockChaining");
         }
@@ -251,8 +260,11 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
             throw new ProviderException("Internal error in input buffering");
         }
 
-        int ret = nativeCrypto.CBCUpdate(nativeContext, plain, plainOffset,
-                                          plainLen, cipher, cipherOffset);
+        int ret;
+        synchronized (this) {
+            ret = nativeCrypto.CBCUpdate(nativeContext, plain, plainOffset,
+                                            plainLen, cipher, cipherOffset);
+        }
         if (ret == -1) {
             throw new ProviderException("Error in Native CipherBlockChaining");
         }
@@ -309,14 +321,16 @@ class NativeCipherBlockChaining extends FeedbackCipher  {
     int encryptFinal(byte[] plain, int plainOffset, int plainLen,
                      byte[] cipher, int cipherOffset) {
 
-        int ret = -1;
+        int ret;
 
-        if(plain == cipher) {
-            ret = nativeCrypto.CBCFinalEncrypt(nativeContext, plain.clone(),
-                                               plainOffset, plainLen, cipher, cipherOffset);
-        } else {
-            ret = nativeCrypto.CBCFinalEncrypt(nativeContext, plain, plainOffset,
-                                                plainLen, cipher, cipherOffset);
+        synchronized (this) {
+            if (plain == cipher) {
+                ret = nativeCrypto.CBCFinalEncrypt(nativeContext, plain.clone(),
+                                                plainOffset, plainLen, cipher, cipherOffset);
+            } else {
+                ret = nativeCrypto.CBCFinalEncrypt(nativeContext, plain, plainOffset,
+                                                    plainLen, cipher, cipherOffset);
+            }
         }
 
         if (ret == -1) {

--- a/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeGaloisCounterMode.java
+++ b/closed/src/java.base/share/classes/com/sun/crypto/provider/NativeGaloisCounterMode.java
@@ -134,18 +134,20 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
      * cipher can be reused (with its original key and iv).
      */
     void reset() {
-        if (aadBuffer == null) {
-            aadBuffer = new ByteArrayOutputStream();
-        } else {
-            aadBuffer.reset();
-        }
+        synchronized (this) {
+            if (aadBuffer == null) {
+                aadBuffer = new ByteArrayOutputStream();
+            } else {
+                aadBuffer.reset();
+            }
 
-        if (ibuffer != null) {
-            ibuffer.reset();
-        }
+            if (ibuffer != null) {
+                ibuffer.reset();
+            }
 
-        if (ibuffer_enc != null) {
-            ibuffer_enc.reset();
+            if (ibuffer_enc != null) {
+                ibuffer_enc.reset();
+            }
         }
     }
 
@@ -153,16 +155,18 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
      * Save the current content of this cipher.
      */
     void save() {
-        aadBufferSave =
-            ((aadBuffer == null || aadBuffer.size() == 0)?
-             null : aadBuffer.toByteArray());
+        synchronized (this) {
+            aadBufferSave =
+                ((aadBuffer == null || aadBuffer.size() == 0) ?
+                    null : aadBuffer.toByteArray());
 
-        if (ibuffer != null) {
-            ibufferSave = ibuffer.toByteArray();
-        }
+            if (ibuffer != null) {
+                ibufferSave = ibuffer.toByteArray();
+            }
 
-        if (ibuffer_enc != null) {
-            ibufferSave_enc = ibuffer_enc.toByteArray();
+            if (ibuffer_enc != null) {
+                ibufferSave_enc = ibuffer_enc.toByteArray();
+            }
         }
     }
 
@@ -170,22 +174,24 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
      * Restores the content of this cipher to the previous saved one.
      */
     void restore() {
-        if (aadBuffer != null) {
-            aadBuffer.reset();
+        synchronized (this) {
+            if (aadBuffer != null) {
+                aadBuffer.reset();
 
-            if (aadBufferSave != null) {
-                aadBuffer.write(aadBufferSave, 0, aadBufferSave.length);
+                if (aadBufferSave != null) {
+                    aadBuffer.write(aadBufferSave, 0, aadBufferSave.length);
+                }
             }
-        }
 
-        if (ibuffer != null && ibufferSave != null) {
-            ibuffer.reset();
-            ibuffer.write(ibufferSave, 0, ibufferSave.length);
-        }
+            if (ibuffer != null && ibufferSave != null) {
+                ibuffer.reset();
+                ibuffer.write(ibufferSave, 0, ibufferSave.length);
+            }
 
-        if (ibuffer_enc != null && ibufferSave_enc != null) {
-            ibuffer_enc.reset();
-            ibuffer_enc.write(ibufferSave_enc, 0, ibufferSave_enc.length);
+            if (ibuffer_enc != null && ibufferSave_enc != null) {
+                ibuffer_enc.reset();
+                ibuffer_enc.write(ibufferSave_enc, 0, ibufferSave_enc.length);
+            }
         }
     }
 
@@ -232,23 +238,22 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
                 keyValue.length + " bytes");
         }
 
-        this.key = keyValue.clone();
-        this.iv = ivValue.clone();
-        this.tagLenBytes = tagLenBytes;
-        this.decrypting = decrypting;
+        synchronized (this) {
+            this.key = keyValue.clone();
+            this.iv = ivValue.clone();
+            this.tagLenBytes = tagLenBytes;
+            this.decrypting = decrypting;
 
-        if (aadBuffer == null) {
-            aadBuffer = new ByteArrayOutputStream();
-        } else {
-            aadBuffer.reset();
-        }
- 
-        if (decrypting) {
-            ibuffer = new ByteArrayOutputStream();
-        }
-
-        if (!decrypting) {
-            ibuffer_enc = new ByteArrayOutputStream();
+            if (aadBuffer == null) {
+                aadBuffer = new ByteArrayOutputStream();
+            } else {
+                aadBuffer.reset();
+            }
+            if (decrypting) {
+                ibuffer = new ByteArrayOutputStream();
+            } else {
+                ibuffer_enc = new ByteArrayOutputStream();
+            }
         }
     }
 
@@ -277,12 +282,14 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
      * @since 1.8
      */
     void updateAAD(byte[] src, int offset, int len) {
-        if (aadBuffer != null) {
-            aadBuffer.write(src, offset, len);
-        } else {
-            // update has already been called
-            throw new IllegalStateException
-                ("Update has been called; no more AAD data");
+        synchronized (this) {
+            if (aadBuffer != null) {
+                aadBuffer.write(src, offset, len);
+            } else {
+                // update has already been called
+                throw new IllegalStateException
+                    ("Update has been called; no more AAD data");
+            }
         }
     }
 
@@ -303,13 +310,18 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
      * @return the number of bytes placed into the <code>out</code> buffer
      */
     int encrypt(byte[] in, int inOfs, int len, byte[] out, int outOfs) {
-        checkDataLength(ibuffer_enc.size(), len);
+        synchronized (this) {
+            if (ibuffer_enc == null) {
+                ibuffer_enc = new ByteArrayOutputStream();
+            }
+            checkDataLength(ibuffer_enc.size(), len);
 
-        if (len > 0) {
-            // store internally until encryptFinal is called because
-            // spec mentioned that only return recovered data after tag
-            // is successfully verified
-            ibuffer_enc.write(in, inOfs, len);
+            if (len > 0) {
+                // store internally until encryptFinal is called because
+                // spec mentioned that only return recovered data after tag
+                // is successfully verified
+                ibuffer_enc.write(in, inOfs, len);
+            }
         }
 
         return 0;
@@ -322,13 +334,15 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
     int encrypt(byte[] in, int inOfs, int len) {
         // store internally until encryptFinal
         ArrayUtil.nullAndBoundsCheck(in, inOfs, len);
-        if (len > 0) {
-            if (ibuffer_enc == null) {
-                ibuffer_enc = new ByteArrayOutputStream();
+        synchronized (this) {
+            if (len > 0) {
+                if (ibuffer_enc == null) {
+                    ibuffer_enc = new ByteArrayOutputStream();
+                }
+                ibuffer_enc.write(in, inOfs, len);
             }
-            ibuffer_enc.write(in, inOfs, len);
+            return len;
         }
-        return len;
     }
 
     /**
@@ -343,40 +357,51 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
      */
     int encryptFinal(byte[] in, int inOfs, int len, byte[] out, int outOfs)
         throws IllegalBlockSizeException, ShortBufferException {
+        byte[] keyCopy;
+        byte[] ivCopy;
+        byte[] aad;
+        int localTagLenBytes;
+        int ret;
+        synchronized (this) {
+            localTagLenBytes = tagLenBytes;
 
-        if (len > MAX_BUF_SIZE - tagLenBytes) {
-            throw new ShortBufferException
-                ("Can't fit both data and tag into one buffer");
+            if (len > (MAX_BUF_SIZE - localTagLenBytes)) {
+                throw new ShortBufferException
+                    ("Can't fit both data and tag into one buffer");
+            }
+
+            if ((out.length - outOfs) < (len + localTagLenBytes)) {
+                throw new ShortBufferException("Output buffer too small");
+            }
+
+            checkDataLength(ibuffer_enc.size(), len);
+
+            if (len > 0) {
+                ibuffer_enc.write(in, inOfs, len);
+            }
+
+            // refresh 'in' to all buffered-up bytes
+            in = ibuffer_enc.toByteArray();
+            ibuffer_enc.reset();
+
+            aad = (((aadBuffer == null) || (aadBuffer.size() == 0)) ? emptyAAD : aadBuffer.toByteArray());
+
+            // avoid any race conditions in OpenSSL when the key/iv are used concurrently
+            keyCopy = key.clone();
+            ivCopy = iv.clone();
+
+            ret = nativeCrypto.GCMEncrypt(keyCopy, keyCopy.length,
+                    ivCopy, ivCopy.length,
+                    in, 0, in.length,
+                    out, outOfs,
+                    aad, aad.length, localTagLenBytes);
         }
 
-        if (out.length - outOfs < (len + tagLenBytes)) {
-            throw new ShortBufferException("Output buffer too small");
-        }
-
-        checkDataLength(ibuffer_enc.size(), len);
-
-        if (len > 0) {
-            ibuffer_enc.write(in, inOfs, len);
-        }
-
-        // refresh 'in' to all buffered-up bytes
-        in = ibuffer_enc.toByteArray();
-        inOfs = 0;
-        len = in.length;
-        ibuffer_enc.reset();
-
-        byte[] aad = ((aadBuffer == null || aadBuffer.size() == 0) ? emptyAAD : aadBuffer.toByteArray());
-
-        int ret = nativeCrypto.GCMEncrypt(key, key.length,
-                iv, iv.length,
-                in, inOfs, len,
-                out, outOfs,
-                aad, aad.length, tagLenBytes);
         if (ret == -1) {
             throw new ProviderException("Error in Native GaloisCounterMode");
         }
 
-        return (len + tagLenBytes);
+        return in.length + localTagLenBytes;
     }
 
     /**
@@ -437,13 +462,18 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
      * @return the number of bytes placed into the <code>out</code> buffer
      */
     int decrypt(byte[] in, int inOfs, int len, byte[] out, int outOfs) {
-        checkDataLength(ibuffer.size(), len);
+        synchronized (this) {
+            if (ibuffer == null) {
+                ibuffer = new ByteArrayOutputStream();
+            }
+            checkDataLength(ibuffer.size(), len);
 
-        if (len > 0) {
-            // store internally until decryptFinal is called because
-            // spec mentioned that only return recovered data after tag
-            // is successfully verified
-            ibuffer.write(in, inOfs, len);
+            if (len > 0) {
+                // store internally until decryptFinal is called because
+                // spec mentioned that only return recovered data after tag
+                // is successfully verified
+                ibuffer.write(in, inOfs, len);
+            }
         }
 
         return 0;
@@ -472,45 +502,59 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
         if (len < 0) {
             throw new ProviderException("Input length is negative");
         }
-        if (len < tagLenBytes - ibuffer.size()) {
-            throw new AEADBadTagException("Input too short - need tag");
+
+        byte[] keyCopy;
+        byte[] ivCopy;
+        byte[] aad;
+        int localTagLenBytes;
+        int ret;
+        // need to synchronize this block as if there are concurrent calls to decryptFinal
+        // the shared variables aadBuffer and ibuffer may corrupt input and cause a segfault
+        // in openssl code
+        synchronized (this) {
+            int bufSize = ibuffer.size();
+            localTagLenBytes = tagLenBytes;
+
+            if (len < (localTagLenBytes - bufSize)) {
+                throw new AEADBadTagException("Input too short - need tag");
+            }
+
+            if (len > (MAX_BUF_SIZE - bufSize)) {
+                throw new ProviderException("SunJCE provider only supports "
+                    + "a positive input size up to " + MAX_BUF_SIZE + " bytes");
+            }
+
+            if ((out.length - outOfs) < (len + bufSize - localTagLenBytes)) {
+                throw new ShortBufferException("Output buffer too small");
+            }
+
+            if (len > 0) {
+                ibuffer.write(in, inOfs, len);
+            }
+
+            // refresh 'in' to all buffered-up bytes
+            in = ibuffer.toByteArray();
+            ibuffer.reset();
+
+            // avoid any race conditions in OpenSSL when the key/iv are used concurrently
+            keyCopy = key.clone();
+            ivCopy = iv.clone();
+            aad = ((aadBuffer == null) || (aadBuffer.size() == 0)) ?
+                emptyAAD : aadBuffer.toByteArray();
+            aadBuffer = null;
+
+            ret = nativeCrypto.GCMDecrypt(keyCopy, keyCopy.length,
+                    ivCopy, ivCopy.length,
+                    in, 0, in.length,
+                    out, outOfs,
+                    aad, aad.length, localTagLenBytes);
         }
-        if (len > MAX_BUF_SIZE - ibuffer.size()) {
-            throw new ProviderException("SunJCE provider only supports "
-                + "a positive input size up to " + MAX_BUF_SIZE + " bytes");
-        }
-
-        if (out.length - outOfs < len  + ibuffer.size() - tagLenBytes) {
-            throw new ShortBufferException("Output buffer too small");
-        }
-
-        byte[] aad = ((aadBuffer == null || aadBuffer.size() == 0) ?
-                       emptyAAD : aadBuffer.toByteArray());
-
-        aadBuffer = null;
-
-        if (len > 0) {
-            ibuffer.write(in, inOfs, len);
-        }
-
-        // refresh 'in' to all buffered-up bytes
-        in = ibuffer.toByteArray();
-        inOfs = 0;
-        len = in.length;
-        ibuffer.reset();
-
-        int ret = nativeCrypto.GCMDecrypt(key, key.length,
-                iv, iv.length,
-                in, inOfs, len,
-                out, outOfs,
-                aad, aad.length, tagLenBytes);
 
         if (ret == -2) {
             throw new AEADBadTagException("Tag mismatch!");
         } else if (ret == -1) {
             throw new ProviderException("Error in Native GaloisCounterMode");
         }
-
 
         return ret;
     }
@@ -580,17 +624,20 @@ final class NativeGaloisCounterMode extends FeedbackCipher {
 
     // return tag length in bytes
     int getTagLen() {
-
         return this.tagLenBytes;
     }
 
     int getBufferedLength() {
-        if (ibuffer != null && decrypting) {
-            return ibuffer.size();
-        }
-
-        if (ibuffer_enc != null && !decrypting) {
-            return ibuffer_enc.size();
+        synchronized (this) {
+            if (decrypting) {
+                if (ibuffer != null) {
+                    return ibuffer.size();
+                }
+            } else {
+                if (ibuffer_enc != null) {
+                    return ibuffer_enc.size();
+                }
+            }
         }
 
         return 0;


### PR DESCRIPTION
This PR is an edited version of a previous PR: #59. The previous PR was created to fix a crash in native crypto reported on an internal ticketing system. However, the JDK failed some tests after merging that commit in the source code so the commit was reverted. Hence, I open this PR to fix those issues.

In this commit:
  * I fix the issue that was failing the tests. The issue was that the length of the processed data was not being returned back at the end of the function. So I added that in the return statement.
  * I also minimize the synchronization blocks to optimize performance. In the previous PR, synchronization did fix the issue so it was merged. In this PR, I was able to completely remove one of the 2 synchronization blocks and minimize the other, without triggering the crash that was described in the jazz ticket. The one `synchronized` block that is left is needed for the following 2 calls:
    * `ibuffer.size()`
    * `ibuffer.toByteArray()`

Fix for internal ref 145527.

Signed-off-by: Samer Almasri <samasri@ibm.com>