### PR TITLE
(0.27.0) Set system property vm.jvmti to true

### DIFF
--- a/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
+++ b/closed/test/jtreg-ext/requires/OpenJ9PropsExt.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2019, 2020 All Rights Reserved
+ * (c) Copyright IBM Corp. 2019, 2021 All Rights Reserved
  * ===========================================================================
  * 
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ public class OpenJ9PropsExt implements Callable<Map<String, String>> {
         try {
             map.put("vm.graal.enabled", "false");
             map.put("vm.bits", vmBits());
+            map.put("vm.jvmti", "true");
         }
         catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
Cherry pick https://github.com/ibmruntimes/openj9-openjdk-jdk16/pull/72 for the 0.27 release. May be useful, and the change isn't harmful.